### PR TITLE
fix: resolve messages get shuffled in whole chat screenshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@
 plugins {
     id "dev.architectury.architectury-pack200" version "0.1.3"
     id 'org.jetbrains.kotlin.jvm' version '1.6.10'
-    id "gg.essential.loom" version "0.10.0.3"
+    id "cc.polyfrost.loom" version "0.10.0.5"
     id "net.kyori.blossom" version "1.3.0"
     id "java"
 }
@@ -27,7 +27,7 @@ compileJava.options.encoding = 'UTF-8'
 loom {
     launchConfigs {
         client {
-            arg("--tweakClass", "cc.polyfrost.oneconfigwrapper.OneConfigWrapper")
+            arg("--tweakClass", "cc.polyfrost.oneconfig.loader.stage0.LaunchWrapperTweaker")
             property("mixin.debug.export", "true")
         }
     }
@@ -51,7 +51,6 @@ configurations {
 
 repositories {
     maven { url 'https://repo.polyfrost.cc/releases'}
-    maven { url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
 }
 
 dependencies {
@@ -60,7 +59,7 @@ dependencies {
     forge("net.minecraftforge:forge:1.8.9-11.15.1.2318-1.8.9")
     compileOnly ('org.spongepowered:mixin:0.7.11-SNAPSHOT')
     compileOnly('cc.polyfrost:oneconfig-1.8.9-forge:0.2.0-alpha+')
-    include('cc.polyfrost:oneconfig-wrapper-launchwrapper:1.0.0-alpha+')
+    include('cc.polyfrost:oneconfig-wrapper-launchwrapper:1.0.0-beta+')
     modRuntimeOnly("me.djtheredstoner:DevAuth-forge-legacy:1.1.0")
 }
 
@@ -108,6 +107,6 @@ jar {
             'ForceLoadAsMod': true,
             'MixinConfigs': "mixins.${mod_id}.json",
             "TweakOrder": "0",
-            "TweakClass": "cc.polyfrost.oneconfigwrapper.OneConfigWrapper",
+            "TweakClass": "cc.polyfrost.oneconfig.loader.stage0.LaunchWrapperTweaker"
     )
 }

--- a/src/main/kotlin/cc/woverflow/chatting/Chatting.kt
+++ b/src/main/kotlin/cc/woverflow/chatting/Chatting.kt
@@ -2,9 +2,9 @@ package cc.woverflow.chatting
 
 import cc.polyfrost.oneconfig.libs.universal.UDesktop
 import cc.polyfrost.oneconfig.libs.universal.UResolution
+import cc.polyfrost.oneconfig.utils.Notifications
 import cc.polyfrost.oneconfig.utils.commands.CommandManager
 import cc.polyfrost.oneconfig.utils.dsl.browseLink
-import cc.polyfrost.oneconfig.utils.Notifications
 import cc.polyfrost.oneconfig.utils.gui.GuiUtils
 import cc.woverflow.chatting.chat.ChatSearchingManager
 import cc.woverflow.chatting.chat.ChatShortcuts
@@ -41,6 +41,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.HashMap
+import kotlin.collections.LinkedHashMap
 
 
 @Mod(
@@ -116,7 +117,8 @@ object Chatting {
             if (isBetterChat) {
                 Notifications.INSTANCE.send(
                     NAME,
-                    "BetterChat can be removed as it is replaced by Chatting. Click here to open your mods folder to delete the BetterChat file.", Runnable {
+                    "BetterChat can be removed as it is replaced by Chatting. Click here to open your mods folder to delete the BetterChat file.",
+                    Runnable {
                         UDesktop.open(File("./mods"))
                     })
             }
@@ -214,7 +216,7 @@ object Chatting {
     fun screenshotChat(scrollPos: Int) {
         val hud = Minecraft.getMinecraft().ingameGUI
         val chat = hud.chatGUI
-        val chatLines = HashMap<String, ChatLine>()
+        val chatLines = LinkedHashMap<String, ChatLine>()
         ChatSearchingManager.filterMessages(
             ChatSearchingManager.lastSearch,
             (chat as GuiNewChatAccessor).drawnChatLines


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- resolve messages get shuffled in whole chat screenshots
- updated to new OneConfig wrapper

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #18 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fixed messages get shuffled in whole chat screenshots
```