### PR TITLE
fix: resolve duplicated lines are missing in chat screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `Chatting`
 A chat mod adding utilities such as extremely customizable chat tabs, chat shortcuts, chat screenshots, and message copying.\
-<img alt="downloads" src="https://img.shields.io/github/downloads/W-OVERFLOW/Chatting/total?color=F5C400&style=for-the-badge" /> <img alt="downloads latest" src="https://img.shields.io/github/downloads-pre/W-OVERFLOW/Chatting/latest/total?color=F5C400&style=for-the-badge" />\
+<img alt="downloads" src="https://img.shields.io/github/downloads/Polyfrost/Chatting/total?color=F5C400&style=for-the-badge" /> <img alt="downloads latest" src="https://img.shields.io/github/downloads-pre/Polyfrost/Chatting/latest/total?color=F5C400&style=for-the-badge" />\
 [Report a Bug][bugreps]
 ·
 [Request a Feature][featreqs]
@@ -11,6 +11,6 @@ A chat mod adding utilities such as extremely customizable chat tabs, chat short
 
 </div>
 
-[bugreps]: https://github.com/W-OVERFLOW/Chatting/issues
-[featreqs]: https://woverflow.cc/discord
+[bugreps]: https://github.com/Polyfrost/Chatting/issues
+[featreqs]: https://polyfrost.cc/discord
 [docs]: docs/docs.md

--- a/src/main/java/cc/woverflow/chatting/mixin/GuiNewChatMixin.java
+++ b/src/main/java/cc/woverflow/chatting/mixin/GuiNewChatMixin.java
@@ -28,7 +28,7 @@ import java.awt.datatransfer.Transferable;
 import java.awt.image.BufferedImage;
 import java.util.List;
 
-@Mixin(value = GuiNewChat.class, priority = Integer.MIN_VALUE)
+@Mixin(value = GuiNewChat.class, priority = 990)
 public abstract class GuiNewChatMixin extends Gui implements GuiNewChatHook {
     @Unique
     private int chatting$right = 0;
@@ -243,7 +243,7 @@ public abstract class GuiNewChatMixin extends Gui implements GuiNewChatHook {
             ChatLine fullLine = this.getFullMessage(subLine);
             if (GuiScreen.isShiftKeyDown()) {
                 if (fullLine != null) {
-                    BufferedImage image = Chatting.INSTANCE.screenshotLine(fullLine);
+                    BufferedImage image = Chatting.INSTANCE.screenshotLine(subLine);
                     if (image != null) RenderUtils.copyToClipboard(image);
                 }
                 return null;

--- a/src/main/java/cc/woverflow/chatting/mixin/GuiNewChatMixin_SmoothMessages.java
+++ b/src/main/java/cc/woverflow/chatting/mixin/GuiNewChatMixin_SmoothMessages.java
@@ -69,7 +69,7 @@ public abstract class GuiNewChatMixin_SmoothMessages {
         return line;
     }
 
-    @ModifyArg(method = "drawChat", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;FFI)I"), index = 3)
+    @ModifyArg(method = "drawChat", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;FFI)I"))
     private int modifyTextOpacity(int original) {
         if (ChattingConfig.INSTANCE.getSmoothChat() && chatting$lineBeingDrawn <= chatting$newLines) {
             int opacity = (original >> 24) & 0xFF;

--- a/src/main/kotlin/cc/woverflow/chatting/Chatting.kt
+++ b/src/main/kotlin/cc/woverflow/chatting/Chatting.kt
@@ -195,7 +195,7 @@ object Chatting {
         val chat = hud.chatGUI
         val i = MathHelper.floor_float(chat.chatWidth / chat.chatScale)
         return screenshot(
-            hashMapOf<String, ChatLine>().also {
+            hashMapOf<ChatLine, String>().also {
                 GuiUtilRenderComponents.splitText(
                     line.chatComponent,
                     i,
@@ -203,7 +203,7 @@ object Chatting {
                     false,
                     false
                 ).map { it.formattedText }.reversed().forEach { string ->
-                    it[string] = line
+                    it[line] = string
                 }
             }
         )
@@ -216,7 +216,7 @@ object Chatting {
     fun screenshotChat(scrollPos: Int) {
         val hud = Minecraft.getMinecraft().ingameGUI
         val chat = hud.chatGUI
-        val chatLines = LinkedHashMap<String, ChatLine>()
+        val chatLines = LinkedHashMap<ChatLine, String>()
         ChatSearchingManager.filterMessages(
             ChatSearchingManager.lastSearch,
             (chat as GuiNewChatAccessor).drawnChatLines
@@ -226,14 +226,14 @@ object Chatting {
                     Minecraft.getMinecraft().gameSettings.chatHeightFocused / 9
                 )
             for (i in scrollPos until drawnLines.size.coerceAtMost(scrollPos + chatHeight)) {
-                chatLines[drawnLines[i].chatComponent.formattedText] = drawnLines[i]
+                chatLines[drawnLines[i]] = drawnLines[i].chatComponent.formattedText
             }
 
             screenshot(chatLines)?.copyToClipboard()
         }
     }
 
-    private fun screenshot(messages: HashMap<String, ChatLine>): BufferedImage? {
+    private fun screenshot(messages: HashMap<ChatLine, String>): BufferedImage? {
         if (messages.isEmpty()) {
             Notifications.INSTANCE.send("Chatting", "Chat window is empty.")
             return null
@@ -247,15 +247,15 @@ object Chatting {
         }
 
         val fr: FontRenderer = ModCompatHooks.fontRenderer
-        val width = messages.maxOf { fr.getStringWidth(it.key) + (if (ChattingConfig.showChatHeads && ((it.value as ChatLineHook).hasDetected() || ChattingConfig.offsetNonPlayerMessages)) 10 else 0) } + 4
+        val width = messages.maxOf { fr.getStringWidth(it.value) + (if (ChattingConfig.showChatHeads && ((it.key as ChatLineHook).hasDetected() || ChattingConfig.offsetNonPlayerMessages)) 10 else 0) } + 4
         val fb: Framebuffer = createBindFramebuffer(width * 2, (messages.size * 9) * 2)
         val file = File(Minecraft.getMinecraft().mcDataDir, "screenshots/chat/" + fileFormatter.format(Date()))
 
         GlStateManager.scale(2f, 2f, 1f)
         val scale = Minecraft.getMinecraft().gameSettings.chatScale
         GlStateManager.scale(scale, scale, 1f)
-        messages.entries.forEachIndexed { i: Int, entry: MutableMap.MutableEntry<String, ChatLine> ->
-            ModCompatHooks.redirectDrawString(entry.key, 0f, (messages.size - 1 - i) * 9f, 0xffffff, entry.value, true)
+        messages.entries.forEachIndexed { i: Int, entry: MutableMap.MutableEntry<ChatLine, String> ->
+            ModCompatHooks.redirectDrawString(entry.value, 0f, (messages.size - 1 - i) * 9f, 0xffffff, entry.key, true)
         }
 
         val image = fb.screenshot(file)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- fixed duplicated lines are missing in chat screenshots (same strings would result in duplicated keys)
- fixed chatBox always rendering at the bottom (set mixin priority from Integer.MIN_VALUE to 990)
- fixed single line screenshot always capturing the top line
- fixed weird InvalidInjectionException (removed index, because there is only one integer in the method's signature)
- changed readme links to Polyfrost

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fixed duplicated lines are missing in chat screenshots
fixed chatBox always rendering at the bottom
fixed single line screenshot always capturing the top line
```