### PR TITLE
Localize Key Name to Operating System

### DIFF
--- a/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
@@ -1,6 +1,7 @@
 package org.polyfrost.chatting.mixin;
 
 import cc.polyfrost.oneconfig.libs.universal.UResolution;
+import org.apache.commons.lang3.SystemUtils;
 import org.polyfrost.chatting.chat.*;
 import org.polyfrost.chatting.config.ChattingConfig;
 import org.polyfrost.chatting.gui.components.ClearButton;
@@ -35,6 +36,15 @@ import java.util.List;
 @Mixin(GuiChat.class)
 public abstract class GuiChatMixin extends GuiScreen {
 
+    /**
+     * Gets the modifier key name depending on the operating system
+     * @return "OPT" if macOS, otherwise, "ALT"
+     */
+    @Unique
+    private static String chatting$getModifierKey() {
+        return (SystemUtils.IS_OS_MAC) ? "OPT" : "ALT";
+    }
+
     @Unique
     private static final List<String> COPY_TOOLTIP = Lists.newArrayList(
             "\u00A7e\u00A7lCopy To Clipboard",
@@ -43,7 +53,7 @@ public abstract class GuiChatMixin extends GuiScreen {
             "\u00A7b\u00A7lSHIFT CLICK\u00A7r \u00A78- \u00A77Screenshot Line",
             "",
             "\u00A7e\u00A7lModifiers",
-            "\u00A7b\u00A7lALT\u00A7r \u00A78- \u00A77Formatting Codes");
+            "\u00A7b\u00A7l"+ chatting$getModifierKey() + "\u00A7r \u00A78- \u00A77Formatting Codes");
 
     private SearchButton searchButton;
 

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
@@ -1,7 +1,7 @@
 package org.polyfrost.chatting.mixin;
 
+import cc.polyfrost.oneconfig.libs.universal.UDesktop;
 import cc.polyfrost.oneconfig.libs.universal.UResolution;
-import org.apache.commons.lang3.SystemUtils;
 import org.polyfrost.chatting.chat.*;
 import org.polyfrost.chatting.config.ChattingConfig;
 import org.polyfrost.chatting.gui.components.ClearButton;
@@ -42,7 +42,7 @@ public abstract class GuiChatMixin extends GuiScreen {
      */
     @Unique
     private static String chatting$getModifierKey() {
-        return (SystemUtils.IS_OS_MAC) ? "OPTION" : "ALT";
+        return (UDesktop.isMac()) ? "OPTION" : "ALT";
     }
 
     @Unique

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
@@ -38,11 +38,11 @@ public abstract class GuiChatMixin extends GuiScreen {
 
     /**
      * Gets the modifier key name depending on the operating system
-     * @return "OPT" if macOS, otherwise, "ALT"
+     * @return "OPTION" if macOS, otherwise, "ALT"
      */
     @Unique
     private static String chatting$getModifierKey() {
-        return (SystemUtils.IS_OS_MAC) ? "OPT" : "ALT";
+        return (SystemUtils.IS_OS_MAC) ? "OPTION" : "ALT";
     }
 
     @Unique


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add chatting$getModifierKey() in GUIChatMixin to allow for OS-specific text
Change COPY_TOOLTIP in GUIChatMixin to use the new function

Depending on the operating system, this will show the user the proper key to press. This was prompted by a user asking me where the ALT key was on their keyboard. 

This does not need any logic change to actual keypress detection, as that already works. It is solely a visual change to the chat copy hover message. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No open GitHub issues are relevant. 

## How to test
<!-- Provide steps to test this PR -->
Launch the game, and hover over a chat message. Verify the text is appropriate to the operating system. If on macOS, it will be "OPTION". Otherwise, it will be "ALT".

macOS verification: 
<img width="1188" alt="image" src="https://github.com/Polyfrost/Chatting/assets/29870899/ddf2e4c9-233f-4f6a-b885-6ebeb6fccbe5">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Change modifier key text in the chat copy hover message to correspond to the operating system 
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
--> No