### PR TITLE
fix gl state on chat animations

### DIFF
--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatWindow.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatWindow.kt
@@ -8,6 +8,7 @@ import cc.polyfrost.oneconfig.libs.universal.UGraphics.GL
 import cc.polyfrost.oneconfig.libs.universal.UMatrixStack
 import cc.polyfrost.oneconfig.utils.dsl.*
 import net.minecraft.client.gui.*
+import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.util.ChatComponentText
 import org.polyfrost.chatting.config.ChattingConfig
 import org.polyfrost.chatting.utils.EaseOutQuart
@@ -57,6 +58,8 @@ class ChatWindow : BasicHud(true) {
         val widthEnd = position.width + (if (mc.ingameGUI.chatGUI.chatOpen) 20 else 0) * scale
         val heightEnd = if (height == 0) 0f else (height + paddingY * 2f) * scale
         val duration = ChattingConfig.bgDuration
+        GlStateManager.enableAlpha()
+        GlStateManager.enableBlend()
         if (widthEnd != widthAnimation.end) {
             widthAnimation = if (ChattingConfig.smoothBG)
                 EaseOutQuart(duration, currentWidth, widthEnd, false)
@@ -73,6 +76,8 @@ class ChatWindow : BasicHud(true) {
         nanoVG(true) {
             drawBackground(position.x, position.bottomY - animationHeight, currentWidth, animationHeight, scale)
         }
+        GlStateManager.disableBlend()
+        GlStateManager.disableAlpha()
     }
 
     fun getAlphaBG(): Int {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes GL state on opening/closing chat. Should fix issues with text and icons going black.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
reported on discord

## How to test
<!-- Provide steps to test this PR -->
open and close chat. tellinq's potion hud is a good hud component to test with

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fix black icons and text when opening and closing chat
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->