### PR TITLE
Allow for custom messages.

### DIFF
--- a/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_ChatSearching.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_ChatSearching.java
@@ -2,9 +2,11 @@ package org.polyfrost.chatting.mixin;
 
 import net.minecraft.client.gui.ChatLine;
 import net.minecraft.client.gui.GuiNewChat;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IChatComponent;
 import org.objectweb.asm.Opcodes;
 import org.polyfrost.chatting.chat.ChatSearchingManager;
+import org.polyfrost.chatting.chat.ChatTabs;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -13,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Mixin(GuiNewChat.class)
@@ -26,6 +29,10 @@ public class GuiNewChatMixin_ChatSearching {
 
     @Redirect(method = "drawChat", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/GuiNewChat;drawnChatLines:Ljava/util/List;", opcode = Opcodes.GETFIELD))
     private List<ChatLine> injected(GuiNewChat instance) {
+        List<ChatLine> chatTabMessages = ChatSearchingManager.filterChatTabMessages(ChatSearchingManager.INSTANCE.getLastSearch());
+        if (chatTabMessages != null) {
+            return chatTabMessages;
+        }
         return ChatSearchingManager.filterMessages(ChatSearchingManager.INSTANCE.getLastSearch(), drawnChatLines);
     }
 }

--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatSearchingManager.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatSearchingManager.kt
@@ -4,6 +4,8 @@ import cc.polyfrost.oneconfig.libs.caffeine.cache.Cache
 import cc.polyfrost.oneconfig.libs.caffeine.cache.Caffeine
 import cc.polyfrost.oneconfig.libs.universal.wrappers.message.UTextComponent
 import net.minecraft.client.gui.ChatLine
+import net.minecraft.util.ChatComponentText
+import org.polyfrost.chatting.chat.ChatTabs.currentTabs
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -38,5 +40,18 @@ object ChatSearchingManager {
             })
             cache.getIfPresent(text)
         }
+    }
+
+    @JvmStatic
+    fun filterChatTabMessages(text: String): List<ChatLine>? {
+        val currentTabs = currentTabs.firstOrNull()
+        if (currentTabs?.messages?.isEmpty() == false) {
+            val list: MutableList<ChatLine> = ArrayList()
+            for (message in currentTabs.messages?: emptyList()) {
+                list.add(ChatLine(0, ChatComponentText(message), 0))
+            }
+            return filterMessages(text, list)
+        }
+        return null
     }
 }

--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatTab.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatTab.kt
@@ -1,10 +1,14 @@
 package org.polyfrost.chatting.chat
 
+import cc.polyfrost.oneconfig.libs.universal.ChatColor
 import org.polyfrost.chatting.gui.components.TabButton
 import com.google.gson.annotations.SerializedName
 import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.ChatLine
+import net.minecraft.util.ChatComponentText
 import net.minecraft.util.EnumChatFormatting
 import net.minecraft.util.IChatComponent
+import org.polyfrost.chatting.mixin.GuiNewChatAccessor
 import java.util.*
 
 data class ChatTab(
@@ -25,11 +29,12 @@ data class ChatTab(
     val color: Int?,
     @SerializedName("hovered_color") val hoveredColor: Int?,
     @SerializedName("selected_color") val selectedColor: Int?,
-    val prefix: String?,
+    val prefix: String?
 ) {
     lateinit var button: TabButton
     lateinit var compiledRegex: ChatRegexes
     lateinit var compiledIgnoreRegex: ChatRegexes
+    @Transient var messages: List<String>? = ArrayList()
 
     //Ugly hack to make GSON not make button / regex null
     fun initialize() {
@@ -41,6 +46,14 @@ data class ChatTab(
             x += 6 + width
             return@run returnValue
         }, width + 4, 12, this)
+
+        if (messages == null) return
+        messages?.forEach {
+            (Minecraft.getMinecraft().ingameGUI.chatGUI as GuiNewChatAccessor).chatLines.add(
+                0,
+                ChatLine(0, ChatComponentText(ChatColor.translateAlternateColorCodes('&', it)), 0)
+            )
+        }
     }
 
     fun shouldRender(chatComponent: IChatComponent): Boolean {


### PR DESCRIPTION
Description
Allowed the ability for developers to add custom messages to a custom chat tab.
Additional information can be found in what I changed, but it really quite simple.
I had created this before and it didn't work as well as I would have hoped, but should be fully functional now.

Related Issue(s)
N/A

How to test
Create a new instance of ChatTab and set the messages to whatever you want!

Release Notes
NONE

Documentation
Not at the moment as this should be developed further to allow for database storage. I can imagine an in-depth API being created for this feature!