### PR TITLE
I found a better way to achieve messages in Chat Tabs.

### DIFF
--- a/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_ChatSearching.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_ChatSearching.java
@@ -29,10 +29,6 @@ public class GuiNewChatMixin_ChatSearching {
 
     @Redirect(method = "drawChat", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/GuiNewChat;drawnChatLines:Ljava/util/List;", opcode = Opcodes.GETFIELD))
     private List<ChatLine> injected(GuiNewChat instance) {
-        List<ChatLine> chatTabMessages = ChatSearchingManager.filterChatTabMessages(ChatSearchingManager.INSTANCE.getLastSearch());
-        if (chatTabMessages != null) {
-            return chatTabMessages;
-        }
         return ChatSearchingManager.filterMessages(ChatSearchingManager.INSTANCE.getLastSearch(), drawnChatLines);
     }
 }

--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatSearchingManager.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatSearchingManager.kt
@@ -31,6 +31,15 @@ object ChatSearchingManager {
 
     @JvmStatic
     fun filterMessages(text: String, list: List<ChatLine>): List<ChatLine>? {
+        val chatTabMessages = filterChatTabMessages(lastSearch)
+        if (chatTabMessages != null) {
+            return chatTabMessages
+        }
+        return filterMessages2(text, list)
+    }
+
+    @JvmStatic
+    fun filterMessages2(text: String, list: List<ChatLine>): List<ChatLine>? {
         if (text.isBlank()) return list
         val cached = cache.getIfPresent(text)
         return cached ?: run {
@@ -50,7 +59,7 @@ object ChatSearchingManager {
             for (message in currentTabs.messages?: emptyList()) {
                 list.add(ChatLine(0, ChatComponentText(message), 0))
             }
-            return filterMessages(text, list)
+            return filterMessages2(text, list)
         }
         return null
     }

--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatTab.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatTab.kt
@@ -46,14 +46,6 @@ data class ChatTab(
             x += 6 + width
             return@run returnValue
         }, width + 4, 12, this)
-
-        if (messages == null) return
-        messages?.forEach {
-            (Minecraft.getMinecraft().ingameGUI.chatGUI as GuiNewChatAccessor).chatLines.add(
-                0,
-                ChatLine(0, ChatComponentText(ChatColor.translateAlternateColorCodes('&', it)), 0)
-            )
-        }
     }
 
     fun shouldRender(chatComponent: IChatComponent): Boolean {


### PR DESCRIPTION
Its basically the same as my last commit, but smarter. Now instead of adding the messages to the lines. We now only display old messages (aka those that are in the messages list) and showing new ones in both all tab and the chat tab.

The names of the #filterMessages functions could probably be changed