### PR TITLE
Fix: Smooth Message + Editing Messages

### DIFF
--- a/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_SmoothMessages.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_SmoothMessages.java
@@ -84,6 +84,9 @@ public abstract class GuiNewChatMixin_SmoothMessages {
 
     @Inject(method = "printChatMessageWithOptionalDeletion", at = @At("HEAD"))
     private void resetPercentage(IChatComponent chatComponent, int chatLineId, CallbackInfo ci) {
+        if (chatLineId != 0 && ChattingConfig.INSTANCE.getDisableSmoothEdits()) {
+            return;
+        }
         if (!EnumChatFormatting.getTextWithoutFormattingCodes(chatComponent.getUnformattedText()).toLowerCase(Locale.ENGLISH).contains(ChatSearchingManager.INSTANCE.getLastSearch().toLowerCase(Locale.ENGLISH))) {
             return;
         }

--- a/src/main/kotlin/org/polyfrost/chatting/config/ChattingConfig.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/config/ChattingConfig.kt
@@ -105,6 +105,13 @@ object ChattingConfig : Config(
     var messageSpeed = 0.5f
 
     @Switch(
+        name = "Disable for Edits",
+        category = "Animations", subcategory = "Messages",
+        description = "Disable smooth animations for edited messages."
+    )
+    var disableSmoothEdits = true
+
+    @Switch(
         name = "Smooth Chat Background",
         category = "Animations", subcategory = "Background",
         description = "Smoothly animate chat background."
@@ -410,6 +417,7 @@ object ChattingConfig : Config(
         addDependency("hypixelOnlyChatShortcuts", "chatShortcuts")
         addDependency("scrollingSpeed", "smoothScrolling")
         addDependency("messageSpeed", "smoothChat")
+        addDependency("disableSmoothEdits", "smoothChat")
         addDependency("bgDuration", "smoothBG")
         addDependency("peekScrolling", "chatPeek")
         addDependency("chatPeekBind", "chatPeek")


### PR DESCRIPTION
## Description
Fixes the fact that "edited" messages (i.e., same line number) - would still try to apply the smoothing animation, which looked pretty goofy.
https://discord.com/channels/822066990423605249/1292530015661199370

## How to test
Easiest way I know to test this is to use SkyHanni's navigation feature, as that's how I originally ran into this.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Added option to disable smooth messages for edited messages.
```