### PR TITLE
Fixed some fields not being transient

### DIFF
--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatTab.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatTab.kt
@@ -32,9 +32,9 @@ data class ChatTab(
     @SerializedName("selected_color") val selectedColor: Int?,
     val prefix: String?
 ) {
-    lateinit var button: TabButton
-    lateinit var compiledRegex: ChatRegexes
-    lateinit var compiledIgnoreRegex: ChatRegexes
+    @Transient lateinit var button: TabButton
+    @Transient lateinit var compiledRegex: ChatRegexes
+    @Transient lateinit var compiledIgnoreRegex: ChatRegexes
     @Transient var messages: List<String>? = ArrayList()
 
     //Ugly hack to make GSON not make button / regex null


### PR DESCRIPTION
## Description
Fixed a few fields not being transient. Allows the mod to run perfectly fine on Java 9+.
Used to be crashing the mod on startup since Gson was trying to access private fields in Java's `Pattern` class.

## Related Issue(s)
Issue reported on Discord.

## How to test
Build the mod, install it on 1.8.9, then startup the game using a recent Java version (like 17).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->